### PR TITLE
Added game filter methods and game filter object that can filter games

### DIFF
--- a/GameStore/BLL/GameService.cs
+++ b/GameStore/BLL/GameService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using DAL;
 using Entities.Entities;
+using Entities.Entities.DTO.GameFilter;
 
 namespace BLL
 {
@@ -15,6 +16,11 @@ namespace BLL
         public List<Game> GetAllGamesService()
         {
             return gameRepository.GetAllGamesRepository();
+        }
+
+        public List<Game> GetAllGamesByFilterService(IGameFilter gameFilter)
+        {
+            return gameRepository.GetAllGamesByFilterRepository(gameFilter);
         }
 
     }

--- a/GameStore/DAL/GameRepository.cs
+++ b/GameStore/DAL/GameRepository.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using Entities.Entities;
 using Entities.Context;
+using Entities.Entities.DTO.GameFilter;
 
 namespace DAL
 {
@@ -16,6 +17,11 @@ namespace DAL
         public List<Game> GetAllGamesRepository()
         {
             return gameStoreContext.Games.ToList();
+        }
+
+        public List<Game> GetAllGamesByFilterRepository(IGameFilter gameFilter)
+        {
+            return gameFilter.Filter(gameStoreContext.Games).ToList();
         }
     }
 }

--- a/GameStore/Entities/Entities/DTO/GameFilter/GameFilter.cs
+++ b/GameStore/Entities/Entities/DTO/GameFilter/GameFilter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Entities.Entities.DTO.GameFilter
+{
+    public class GameFilter : IGameFilter
+    {
+        //If these are manipulated to invalid ids then the filter will return nothing, which is expected behaviour.
+        public int? GenreId { get; set; }
+        public int? PublisherId { get; set; }
+        public string? SearchString { get; set; }
+        public GameFilter() { }
+
+        public IEnumerable<Game> Filter(IEnumerable<Game> games)
+        {
+            if (this.GenreId != null)
+            {
+                games = games.Where(x => x.GenreId == this.GenreId);
+            }
+            if (this.PublisherId != null)
+            {
+                games = games.Where(x => x.PublisherId == this.PublisherId);
+            }
+            if (this.SearchString!=null)
+            {
+                games = games.Where(x => x.GameName.ToLower().Contains(SearchString.ToLower()));
+            }
+            return games;
+        }
+    }
+}

--- a/GameStore/Entities/Entities/DTO/GameFilter/IGameFilter.cs
+++ b/GameStore/Entities/Entities/DTO/GameFilter/IGameFilter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Entities.Entities.DTO.GameFilter
+{
+    //Interface for game filtering objects
+    public interface IGameFilter
+    {
+        public IEnumerable<Game> Filter(IEnumerable<Game> games);
+    }
+}


### PR DESCRIPTION
The game filter object can be give a publisher id, genre id, and/or search string to filter out games. It can then be passed to GameService.GetAllGamesByFilterService() to get all games that meet the filter.
This object will be useful since it lets us use any combination of filters to filter out games.